### PR TITLE
fix: token being cleared by user status

### DIFF
--- a/src/logic/user.rs
+++ b/src/logic/user.rs
@@ -62,7 +62,8 @@ fn handle_print_token(ctx: &mut Context) -> Result<()> {
 
 async fn user_info(ctx: &mut Context) -> Result<()> {
     let user = api::user::user_info(&ctx.client).await?;
-    let c: Cache = user.clone().into();
+    let mut c: Cache = user.clone().into();
+    c.token = ctx.cache.token.clone();
     ctx.save_cache(c)?;
     ctx.terminal.writeln(user.format_user_info())
 }


### PR DESCRIPTION
Fixes token being cleared after running `cnb user status`.
`user status` refreshes cached user info by converting `UserInfo` into `Cache`, but that conversion initializes `token` as an empty string. This caused the saved cache to overwrite the existing token.
This change preserves the existing token before saving the refreshed cache.